### PR TITLE
Add CI/CD GitHub actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,27 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Log in to GHCR
+      if: hashFiles('Dockerfile') != ''
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Docker image
+      if: hashFiles('Dockerfile') != ''
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+    - name: Install dependencies
+      if: hashFiles('package.json') != ''
+      run: npm ci
+    - name: Run tests
+      if: hashFiles('package.json') != ''
+      run: npm test --if-present

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Bazaar
 Bazaar – A full-stack cross-platform e-commerce marketplace with mobile and web apps. Features real-time AI chat support (OpenAI), automated image fetching, secure payments (Stripe), and modern UX with CI/CD and JWT authentication.
+
+## Continuous Integration & Deployment
+This repository includes GitHub Actions workflows for automatic testing and Docker image deployment:
+
+- **CI** (`.github/workflows/ci.yml`) runs on every push and pull request. It installs Node dependencies and executes `npm test` when a `package.json` file is present.
+- **CD** (`.github/workflows/cd.yml`) builds and pushes a Docker image to GitHub Container Registry whenever a commit is pushed to `main` (or a version tag) and a `Dockerfile` exists.
+
+These pipelines provide a starting point for automated builds and can be extended as the project evolves.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflows for CI and Docker-based CD
- document the automated pipelines in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e28f2df3883338dad4d27bdfaa20b